### PR TITLE
Initial draft of workflow_dispatch based mailer

### DIFF
--- a/.github/workflows/emailer.yaml
+++ b/.github/workflows/emailer.yaml
@@ -1,0 +1,62 @@
+#
+# Emails model uploader about the status of test results alerting them 
+# about whether they need to take any actions to fix issues with their upload
+#
+
+on: 
+  workflow_dispatch:
+    inputs:
+      user_email:
+        description: 'Email address of user'
+        required: true
+        type: string
+      # Other inputs from Flynn here 
+
+  jobs:
+    - name: Send mail
+      uses: dawidd6/action-send-mail@v3
+      with:
+        # Specify connection via URL (replaces server_address, server_port, secure,
+        # username and password)
+        #
+        # Format:
+        #
+        #  * smtp://user:password@server:port
+        #  * smtp+starttls://user:password@server:port
+        connection_url: ${{secrets.MAIL_CONNECTION}}
+        # Required mail server address if not connection_url:
+        server_address: smtp.gmail.com
+        # Server port, default 25:
+        server_port: 465
+        # Optional whether this connection use TLS (default is true if server_port is 465)
+        secure: true
+        # Optional (recommended) mail server username:
+        username: ${{secrets.MAIL_USERNAME}}
+        # Optional (recommended) mail server password:
+        password: ${{secrets.MAIL_PASSWORD}}
+        # Required mail subject:
+        subject: Github Actions job result
+        # Required recipients' addresses:
+        to: ${{ inputs.user_email }}
+        # Required sender full name (address can be skipped):
+        from: Luke Skywalker # <user@example.com>
+        # Optional plain body:
+        body: Build job of ${{github.repository}} completed successfully!
+        # Optional HTML body read from file:
+        html_body: file://README.html
+        # Optional carbon copy recipients:
+        cc: kyloren@example.com,leia@example.com
+        # Optional blind carbon copy recipients:
+        bcc: r2d2@example.com,hansolo@example.com
+        # Optional recipient of the email response:
+        reply_to: luke@example.com
+        # Optional Message ID this message is replying to:
+        in_reply_to: <random-luke@example.com>
+        # Optional unsigned/invalid certificates allowance:
+        ignore_cert: true
+        # Optional converting Markdown to HTML (set content_type to text/html too):
+        convert_markdown: true
+        # Optional attachments:
+        attachments: # TODO Can we attach a test log?
+        # Optional priority: 'high', 'normal' (default) or 'low'
+        priority: low


### PR DESCRIPTION
Uses https://github.com/marketplace/actions/send-email

I left a lot of defaults from the sample shown here: https://github.com/marketplace/actions/send-email#usage

Hopefully the way I added the `to` address makes it clear how to add the rest of the parameters in @FynnBe.

Open question I didn't find the answer to yet is how to add the test log here - can we get that from the runner? 